### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/jefftheitguy/73926829-0d39-4fc5-acbc-6da5af3f4ca3/8d6838ba-92fe-469f-93b3-85e641d6cf0d/_apis/work/boardbadge/859ae915-912f-423e-9ef4-fc96ad07152c)](https://dev.azure.com/jefftheitguy/73926829-0d39-4fc5-acbc-6da5af3f4ca3/_boards/board/t/8d6838ba-92fe-469f-93b3-85e641d6cf0d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/jefftheitguy/73926829-0d39-4fc5-acbc-6da5af3f4ca3/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.